### PR TITLE
MODULES-3897 - added mongo listen port before creating facter

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -1,15 +1,42 @@
 require 'json'
+require 'yaml'
+
+def get_mongod_conf_file
+  if File.exists? '/etc/mongod.conf'
+    file = '/etc/mongod.conf'
+  else
+    file = '/etc/mongodb.conf'
+  end
+  file
+end
 
 Facter.add('mongodb_is_master') do
   setcode do
     if Facter::Core::Execution.which('mongo')
+      file = get_mongod_conf_file
+      config = YAML.load_file(file)
+      mongoPort = nil
+      if config.kind_of?(Hash) # Using a valid YAML file for mongo 2.6
+        unless config['net.port'].nil?
+          mongoPort = "--port #{config['net.port']}"
+        end
+      else # It has to be a key-value config file
+        config = {}
+        File.readlines(file).collect do |line|
+          k,v = line.split('=')
+          config[k.rstrip] = v.lstrip.chomp if k and v
+        end
+        unless config['port'].nil?
+          mongoPort = "--port #{config['port']}"
+        end
+      end
       e = File.exists?('/root/.mongorc.js') ? 'load(\'/root/.mongorc.js\'); ' : ''
 
       # Check if the mongodb server is responding:
-      Facter::Core::Execution.exec("mongo --quiet --eval \"#{e}printjson(db.adminCommand({ ping: 1 }))\"")
+      Facter::Core::Execution.exec("mongo --quiet #{mongoPort} --eval \"#{e}printjson(db.adminCommand({ ping: 1 }))\"")
 
       if $?.success?
-        mongo_output = Facter::Core::Execution.exec("mongo --quiet --eval \"#{e}printjson(db.isMaster())\"")
+        mongo_output = Facter::Core::Execution.exec("mongo --quiet #{mongoPort} --eval \"#{e}printjson(db.isMaster())\"")
         JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 '))['ismaster'] ||= false
       else
         'not_responding'


### PR DESCRIPTION
Correct is_master facter connecting error if mongo listens on a non default port.
This fixes: https://tickets.puppetlabs.com/browse/MODULES-3897
